### PR TITLE
update the torch_tools.py for cuda devices

### DIFF
--- a/cace/tools/torch_tools.py
+++ b/cace/tools/torch_tools.py
@@ -43,13 +43,23 @@ def to_numpy(t: torch.Tensor) -> np.ndarray:
     return t.cpu().detach().numpy()
 
 def init_device(device_str: str) -> torch.device:
-    if device_str == "cuda":
+
+    if "cuda" in device_str: # can be cuda:1 etc.
         assert torch.cuda.is_available(), "No CUDA device available!"
         logging.info(
             f"CUDA version: {torch.version.cuda}, CUDA device: {torch.cuda.current_device()}"
         )
         torch.cuda.init()
-        return torch.device("cuda")
+        return torch.device(device_str)
+        
+    # if device_str == "cuda":
+    #     assert torch.cuda.is_available(), "No CUDA device available!"
+    #     logging.info(
+    #         f"CUDA version: {torch.version.cuda}, CUDA device: {torch.cuda.current_device()}"
+    #     )
+    #     torch.cuda.init()
+    #     return torch.device("cuda")
+        
     if device_str == "mps":
         assert torch.backends.mps.is_available(), "No MPS backend is available!"
         logging.info("Using MPS GPU acceleration")

--- a/cace/tools/torch_tools.py
+++ b/cace/tools/torch_tools.py
@@ -46,11 +46,13 @@ def init_device(device_str: str) -> torch.device:
 
     if "cuda" in device_str: # can be cuda:1 etc.
         assert torch.cuda.is_available(), "No CUDA device available!"
+        torch.cuda.init()
+        device = torch.device(device_str)
+        torch.cuda.set_device(device)
         logging.info(
             f"CUDA version: {torch.version.cuda}, CUDA device: {torch.cuda.current_device()}"
         )
-        torch.cuda.init()
-        return torch.device(device_str)
+        return device
         
     # if device_str == "cuda":
     #     assert torch.cuda.is_available(), "No CUDA device available!"


### PR DESCRIPTION
Allow specifying which single GPU is to be used (e.g., cuda:3) 