### PR TITLE
dimension is fixed for non-pbc system

### DIFF
--- a/cace/modules/ewald.py
+++ b/cace/modules/ewald.py
@@ -426,5 +426,6 @@ class EwaldPotential(nn.Module):
         self.external_field = external_field
 
     def is_orthorhombic(self, cell_matrix):
-        is_orthorhombic = np.allclose(cell_matrix - np.diag(np.diagonal(cell_matrix)), 0)
+        diag_matrix = torch.diag(torch.diagonal(cell_matrix))
+        is_orthorhombic = torch.allclose(cell_matrix, diag_matrix, atol=1e-6)
         return is_orthorhombic

--- a/cace/modules/ewald.py
+++ b/cace/modules/ewald.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from itertools import product
 from typing import Dict
+import numpy as np
 
 class EwaldPotential(nn.Module):
     def __init__(self,
@@ -57,7 +58,8 @@ class EwaldPotential(nn.Module):
         if hasattr(self, 'compute_field') == False:
             self.compute_field = False
         
-        box = data['cell'].view(-1, 3, 3).diagonal(dim1=-2, dim2=-1)
+        # box = data['cell'].view(-1, 3, 3).diagonal(dim1=-2, dim2=-1)
+        box = data['cell'].view(-1, 3, 3)
         r = data['positions']
         q = data[self.feature_key]
         if q.dim() == 1:
@@ -76,12 +78,18 @@ class EwaldPotential(nn.Module):
             mask = batch_now == i  # Create a mask for the i-th configuration
             # Calculate the potential energy for the i-th configuration
             r_raw_now, q_now, box_now = r[mask], q[mask], box[i]
-            if box_now[0] < 1e-6 and box_now[1] < 1e-6 and box_now[2] < 1e-6 and self.exponent == 1:
+            box_diag = box[i].diagonal(dim1=-2, dim2=-1)
+            print(box_now)
+            print(box_now.shape)
+            if box_diag[0] < 1e-6 and box_diag[1] < 1e-6 and box_diag[2] < 1e-6 and self.exponent == 1:
                 # the box is not periodic, we use the direct sum
                 pot, field = self.compute_potential_realspace(r_raw_now, q_now, self.compute_field)
-            elif box_now[0] > 0 and box_now[1] > 0 and box_now[2] > 0:
+            elif box_diag[0] > 0 and box_diag[1] > 0 and box_diag[2] > 0 and self.is_orthorhombic(box_now):
+                box_now = box_now.diagonal(dim1=-2, dim2=-1)
                 pot, field = self.compute_potential_optimized(r_raw_now, q_now, box_now, self.compute_field)
                 #pot, field = self.compute_potential(r_raw_now, q_now, box_now, self.compute_field)
+            elif box_diag[0] > 0 and box_diag[1] > 0 and box_diag[2] > 0 and not self.is_orthorhombic(box_now):
+                pot, field = self.compute_potential_tricilinic(r_raw_now, q_now, box_now, self.compute_field)
             else:
                 raise ValueError("Either all box dimensions must be positive or aperiodic box must be provided.")
 
@@ -316,7 +324,7 @@ class EwaldPotential(nn.Module):
         else:
             raise ValueError("q must be 1D or 2D tensor")
         # q_expanded: [n_node, n_q, 1, 1, 1]
-        # eik: [n_node, n_x, n_x, n_z]
+        # eik: [n_node, n_x, n_y, n_z]
         # sk: [n_q, n_x, n_y, n_z]
         # kfac: [n_x, n_y, n_z]
         eik = eikx_expanded * eiky_expanded * eikz_expanded
@@ -336,6 +344,77 @@ class EwaldPotential(nn.Module):
             q_field = q_field - q / (self.sigma * self.twopi**(3./2.)) * 2.
 
         return pot.real * self.norm_factor, q_field * self.norm_factor
+    
+    # Triclinic box(could be orthorhombic)
+    def compute_potential_tricilinic(self, r_raw, q, cell_now, compute_field=False):
+        device = r_raw.device
+        # cell_now # [3,3] M
+        volume = torch.det(cell_now)
+        # r_frac(s) = M⁻¹ r
+        r_frac = torch.linalg.solve(cell_now, r_raw.T).T
+        # Reciprocal lattice: G = 2π (M^{-1})^T
+        G = 2 * torch.pi * torch.linalg.inv(cell_now).T  # [3,3]
+
+        # max Nk for each axis
+        norms = torch.norm(cell_now, dim=1)
+        Nk = [max(1, int(n.item() / self.dl)) for n in norms]
+        # n1, n2, n3
+        n1 = torch.arange(0, Nk[0] + 1, device=device)
+        n2 = torch.arange(-Nk[1], Nk[1] + 1, device=device)
+        n3 = torch.arange(-Nk[2], Nk[2] + 1, device=device)
+        # nvec -> n1 ∈ [0, Nk[0]], n2 ∈ [–Nk[1], Nk[1]], n3 ∈ [–Nk[2], Nk[2]]
+        nvec = torch.stack(torch.meshgrid(n1, n2, n3, indexing="ij"), dim=-1).reshape(-1, 3)  # [N_total, 3]
+        nvec = nvec.to(G.dtype)
+
+        # kvec = G @ nvec
+        kvec = (G @ nvec.T).T  # [N_total, 3]
+        k_sq = torch.sum(kvec ** 2, dim=1) 
+        # mask for k_sq
+        mask = (k_sq > 0) & (k_sq <= self.k_sq_max) # k_sq_max = (2π/dl)^2, 
+        #M -> Masked size
+        kvec = kvec[mask]     # [M, 3]
+        k_sq = k_sq[mask]     # [M]
+        nvec_masked = nvec[mask]  # [M, 3]
+
+        # symmetry factor
+        factors = torch.ones(nvec_masked.shape[0], device=device, dtype=r_raw.dtype)
+        factors[nvec_masked[:, 0] > 0] = 2.0
+
+        #S(k) = Σ_i q_i e^{i k · r_i}
+        #exp(i k·r) = exp(i 2π n·s) (where s = M⁻¹ r). but here we use k·r
+        k_dot_r = torch.matmul(r_raw, kvec.T)  # [n, M]
+        S_k = torch.sum(q * torch.exp(1j * k_dot_r), dim=0)  # [M]
+
+        # kfac = exp(-σ^2/2 k^2) / k^2 for exponent = 1
+        if self.exponent == 1:
+            kfac = torch.exp(-self.sigma_sq_half * k_sq) / k_sq  # [M]
+        elif self.exponent == 6:
+            # Calculate b_sq and b
+            b_sq = k_sq * self.sigma_sq_half
+            b = torch.sqrt(b_sq)
+
+            # Compute kfac based on the provided expression
+            kfac = -1.0 * k_sq ** (3 / 2) * ( torch.pi ** 0.5 * torch.special.erfc(b) + (1 / (2 * b ** 3) - 1 / b) * torch.exp(-b_sq))
+            #kfac = -1.0 * k_sq ** (3 / 2) * torch.exp(-b_sq) # this assumed a Gaussian smearing
+        
+        # (2π/volume)* sum(factors * kfac * |S(k)|²)
+        # pot = (twopi / volume) * torch.sum( kfac * torch.abs(S_k)**2)
+        pot = (1 / volume) * torch.sum( factors * kfac * torch.abs(S_k)**2)
+
+        # return the field
+        q_field = torch.zeros_like(q, dtype=r_raw.dtype, device=device) # Field due to q
+        if compute_field:
+            sk_field = 2. * kfac * torch.conj(S_k)
+            exp_ikr = torch.exp(1j * k_dot_r)
+            q_field = (factors * torch.real(exp_ikr * sk_field)).sum(dim=1)
+            q_field /= volume
+        
+        remove_self_interaction = False    
+        if remove_self_interaction and self.exponent == 1:
+            pot -= torch.sum(q ** 2) / (self.sigma * self.twopi**(3./2.))
+            q_field = q_field - q / (self.sigma * self.twopi**(3./2.)) * 2.
+
+        return pot.unsqueeze(0) * self.norm_factor, q_field.unsqueeze(1) * self.norm_factor
 
     def add_external_field(self, r_raw, q, box, direction_index, external_field):
         external_field_norm_factor = (self.norm_factor/90.0474)**0.5
@@ -347,3 +426,7 @@ class EwaldPotential(nn.Module):
 
     def change_external_field(self, external_field):
         self.external_field = external_field
+
+    def is_orthorhombic(self, cell_matrix):
+        is_orthorhombic = np.allclose(cell_matrix - np.diag(np.diagonal(cell_matrix)), 0)
+        return is_orthorhombic

--- a/cace/modules/ewald.py
+++ b/cace/modules/ewald.py
@@ -79,8 +79,6 @@ class EwaldPotential(nn.Module):
             # Calculate the potential energy for the i-th configuration
             r_raw_now, q_now, box_now = r[mask], q[mask], box[i]
             box_diag = box[i].diagonal(dim1=-2, dim2=-1)
-            print(box_now)
-            print(box_now.shape)
             if box_diag[0] < 1e-6 and box_diag[1] < 1e-6 and box_diag[2] < 1e-6 and self.exponent == 1:
                 # the box is not periodic, we use the direct sum
                 pot, field = self.compute_potential_realspace(r_raw_now, q_now, self.compute_field)

--- a/cace/modules/polarization.py
+++ b/cace/modules/polarization.py
@@ -63,7 +63,7 @@ class Polarization(nn.Module):
         if len(phases) > 0:
             data[self.phase_key] = torch.stack(phases, dim=0)
         else:
-            data[self.phase_key] = 0.0
+            data[self.phase_key] = torch.zeros((1, *r_now.shape), dtype=torch.complex64, device=r_now.device)
         return data
 
 class Dephase(nn.Module):


### PR DESCRIPTION
for non-periodic system,
data[self.phase_key] = 0.0
caused a problem with below line 
result = data[self.input_key] * data[self.phase_key].unsqueeze(-2).conj()

I modified a bit to ensure data[self.phase_key] have same dim and shape.