### PR TITLE
CACE calculator bug fix

### DIFF
--- a/cace/calculators/cace_calculator.py
+++ b/cace/calculators/cace_calculator.py
@@ -79,10 +79,13 @@ class CACECalculator(Calculator):
         self.stress_key = stress_key
         self.bec_key = bec_key
 
-        if isinstance(external_field, float):
-            self.external_field = external_field
+        if external_field is not None:
+            if isinstance(external_field, float):
+                self.external_field = external_field
+            else:
+                self.external_field = np.array(external_field)
         else:
-            self.external_field = np.array(external_field)
+            self.external_field = None      
         self.output_index = output_index
         
         for param in self.model.parameters():


### PR DESCRIPTION
I just found out that even though we assign external_field as 'None', 
np.array(external_field) is considered as 'not None'.  (np.array(None) is not None)
I think because it gives 'numpy array' type instead of 'None' type.

It caused a key error problem when we are doing MD without field(not computing BEC)