### PR TITLE
cace_calculator update: accept other keys in AtomicData

### DIFF
--- a/cace/calculators/cace_calculator.py
+++ b/cace/calculators/cace_calculator.py
@@ -38,6 +38,7 @@ class CACECalculator(Calculator):
         forces_key: str = 'forces',
         stress_key: str = 'stress',
         bec_key: str = 'bec',
+        data_key: dict = None,
         external_field: Union[float,List[float]] = None,
         keep_neutral: bool = True, # to keep BEC sum to be neutral
         atomic_energies: dict = None,
@@ -79,6 +80,7 @@ class CACECalculator(Calculator):
         self.forces_key = forces_key
         self.stress_key = stress_key
         self.bec_key = bec_key
+        self.data_key = data_key
         self.keep_neutral = keep_neutral
 
         if external_field is not None:
@@ -111,7 +113,8 @@ class CACECalculator(Calculator):
         data_loader = torch_geometric.dataloader.DataLoader(
             dataset=[
                 AtomicData.from_atoms(
-                    atoms, cutoff=self.cutoff
+                    atoms, cutoff=self.cutoff,
+                    data_key=self.data_key,
                 )
             ],
             batch_size=1,


### PR DESCRIPTION
Adding the `data_key` to let `CACECalculator` know which keys they have to read from the `atoms` objects was sufficient because the ASE's `atoms` object retains the initially input `atomic_charge` info in memory throughout the MD simulation. 

I've tested with a short run and had no problem.
ex)
```
calculator = CACECalculator(model_path=cace_nnp, 
                            device='cuda', 
                            energy_key='CACE_energy', 
                            forces_key='CACE_forces',
                            data_key={'atomic_charge': 'atomic_charge'},
                            compute_stress=False,
                            atomic_energies= ... # avg
)
```