### PR TITLE
L2 clean dk

### DIFF
--- a/cace/modules/les_wrapper.py
+++ b/cace/modules/les_wrapper.py
@@ -15,6 +15,7 @@ class LesWrapper(nn.Module):
                  energy_key: str = 'LES_energy',
                  charge_key: str = 'LES_charge',
                  dipole_key: str = None,
+                 quads_key: str = None,
                  kappa_key: str = None,
                  alpha_key: str = None,
                  atomic_number_key: str = None,
@@ -24,6 +25,7 @@ class LesWrapper(nn.Module):
                  bec_output_index: int = None, # option to compute BEC along one axis
                  make_alpha_positive: bool = False,
                  make_kappa_positive: bool = False,
+                 make_quads_traceless: bool = True,
                  add_scalar_alpha: bool = False,
                  scalar_alpha_mlp_sizes: Sequence[int] = [32, 16],
                  scaling_factor_scalar_alpha: float = 0.001,
@@ -45,12 +47,14 @@ class LesWrapper(nn.Module):
         self.energy_key = energy_key
         self.charge_key = charge_key
         self.dipole_key = dipole_key
+        self.quads_key = quads_key
         self.kappa_key = kappa_key
         self.alpha_key = alpha_key
         self.atomic_number_key = atomic_number_key
 
         self.make_alpha_positive = make_alpha_positive
         self.make_kappa_positive = make_kappa_positive
+        self.make_quads_traceless = make_quads_traceless
         self.add_scalar_alpha = add_scalar_alpha
         self.scaling_factor_scalar_alpha = scaling_factor_scalar_alpha
         if self.add_scalar_alpha:
@@ -114,10 +118,18 @@ class LesWrapper(nn.Module):
         if hasattr(self, 'make_kappa_positive') and self.make_kappa_positive:
             data[self.kappa_key] = data[self.kappa_key]**2
 
+        if hasattr(self, 'make_quads_traceless') and self.make_quads_traceless:
+            quads = data[self.quads_key] if self.quads_key in data else None
+            trace = torch.einsum("nii->n", quads)
+            eye = torch.eye(3, device=quads.device, dtype=quads.dtype)
+            quads = quads - (trace[:,None,None] * eye[None,:,:])/3
+            data[self.quads_key] = quads
+
         result = self.les(
             desc=features,
             latent_charges=data[self.charge_key] if features is None else None,
             latent_dipoles=data[self.dipole_key] if self.dipole_key is not None else None,
+            latent_quads=data[self.quads_key] if self.quads_key is not None else None,
             latent_alphas=data[self.alpha_key] if self.alpha_key is not None else None,
             latent_kappas=data[self.kappa_key] if self.kappa_key is not None else None,
             atomic_numbers=data[self.atomic_number_key] if hasattr(self, 'atomic_number_key') and  self.atomic_number_key is not None else None,
@@ -135,6 +147,8 @@ class LesWrapper(nn.Module):
             data[self.dipole_key] = result['latent_dipoles']
         if self.alpha_key is not None:
             data[self.alpha_key] = result['latent_alphas']
+        if self.quads_key is not None:
+            data[self.quads_key] = result['latent_quads']
 
         if self.compute_energy:
             data[self.energy_key] = result['E_lr']

--- a/cace/modules/les_wrapper.py
+++ b/cace/modules/les_wrapper.py
@@ -51,14 +51,12 @@ class LesWrapper(nn.Module):
         self.make_kappa_positive = make_kappa_positive
         self.add_scalar_alpha = add_scalar_alpha
         if self.add_scalar_alpha:
-            from les.module import Atomwise
-            self.atomwise: nn.Module = (
-                Atomwise(
-                    n_layers=3,
-                    n_hidden=[32,16],
-                    add_linear_nn=True,
-                    output_scaling_factor=1, 
-                )
+            self.alpha_scalar_mlp = nn.Sequential(
+                nn.LazyLinear(32, bias=True),
+                nn.SiLU(),
+                nn.Linear(32, 16, bias=True),
+                nn.SiLU(),
+                nn.Linear(16, 1, bias=True)
             )
 
         self.bec_key = bec_key
@@ -105,7 +103,7 @@ class LesWrapper(nn.Module):
             alpha = data[self.alpha_key] if self.alpha_key in data else None
             if alpha.dim() == 3 and alpha.shape[1] == 3 and alpha.shape[2] == 3:
                 desc = data[self.feature_key]
-                a2 = self.atomwise(desc.reshape(desc.shape[0],-1),data["batch"]).squeeze()
+                a2 = self.alpha_scalar_mlp(desc.reshape(desc.shape[0],-1)).squeeze()
                 eye = torch.eye(3,device=a2.device)
                 a2 = a2[:,None,None] * eye[None,:,:]
                 data[self.alpha_key] = data[self.alpha_key] + a2

--- a/cace/modules/tensor_readout.py
+++ b/cace/modules/tensor_readout.py
@@ -15,9 +15,9 @@ class TensorReadout(nn.Module):
         self,
         max_l: int,
         feature_key: str = 'node_feats_l',
-        l0_key: str = 'scalar',
-        l1_key: str = 'vector',
-        l2_key: str = 'quadrupole',
+        l0_key: 'str | list[str]' = 'scalar',
+        l1_key: 'str | list[str]' = 'vector',
+        l2_key: 'str | list[str]' = 'quadrupole',
         n_channel: int = 1,
         l0_output_scale: float = 1.0,
         l1_output_scale: float = 1.0,
@@ -31,23 +31,27 @@ class TensorReadout(nn.Module):
         assert max_l <= 2, "max_l greater than 2 is not supported for direct prediction."
         self.max_l = max_l
         self.feature_key = feature_key
-        self.l0_key = l0_key
-        self.l1_key = l1_key
-        self.l2_key = l2_key
-
+        self.l0_key = [l0_key] if isinstance(l0_key, str) else l0_key
+        self.l1_key = [l1_key] if isinstance(l1_key, str) else l1_key
+        self.l2_key = [l2_key] if isinstance(l2_key, str) else l2_key
         self.l0_output_scale = l0_output_scale
         self.l1_output_scale = l1_output_scale
         self.l2_output_scale = l2_output_scale
 
         self.model_outputs = []
-        self.model_outputs.append(self.l0_key)
-        self.model_outputs.append(self.l1_key)
+        for key in self.l0_key:
+            self.model_outputs.append(key)
+        for key in self.l1_key:
+            self.model_outputs.append(key)
         if max_l >= 2:
-            self.model_outputs.append(self.l2_key)
+            for key in self.l2_key:
+                self.model_outputs.append(key)       
 
         self.required_derivatives = []
-
-        self.tensor_feed_forward = TensorFeedForward(n_channel, lomax=max_l)
+        nout = max(len(self.l0_key),len(self.l1_key),len(self.l2_key))
+        self.n_channel = n_channel
+        tff_dim = self.n_channel * nout
+        self.tensor_feed_forward = TensorFeedForward(tff_dim, lomax=max_l)
 
     def forward(self, data: Dict[str, torch.Tensor], **kwargs) -> Dict[str, torch.Tensor]:
         if self.feature_key not in data:
@@ -59,11 +63,23 @@ class TensorReadout(nn.Module):
             assert 2 in features, f"Features for l=2 not found in data dictionary under key {self.feature_key}."
 
         out = self.tensor_feed_forward(features)
-        data[self.l0_key] = out[0][:,0] * self.l0_output_scale
-        data[self.l1_key] = out[1][:,0] * self.l1_output_scale
+        start, stop = 0, self.n_channel
+        for k in self.l0_key:
+            data[k] = out[0][:, start:stop] * self.l0_output_scale
+            start += self.n_channel
+            stop += self.n_channel
+        start, stop = 0, self.n_channel
+        for k in self.l1_key:
+            data[k] = out[1][:, start:stop] * self.l1_output_scale
+            start += self.n_channel
+            stop += self.n_channel
         if self.max_l >= 2:
-            data[self.l2_key] = out[2][:,0] * self.l2_output_scale
-
+            start, stop = 0, self.n_channel
+            for k in self.l2_key:
+                data[k] = out[2][:, start:stop] * self.l2_output_scale
+                start += self.n_channel
+                stop += self.n_channel
+       
         return data 
 
     def __repr__(self):

--- a/cace/modules/tensor_readout.py
+++ b/cace/modules/tensor_readout.py
@@ -65,20 +65,21 @@ class TensorReadout(nn.Module):
         out = self.tensor_feed_forward(features)
         start, stop = 0, self.n_channel
         for k in self.l0_key:
-            data[k] = out[0][:, start:stop] * self.l0_output_scale
+            data[k] = (out[0][:, start:stop] * self.l0_output_scale).squeeze()
             start += self.n_channel
             stop += self.n_channel
         start, stop = 0, self.n_channel
         for k in self.l1_key:
-            data[k] = out[1][:, start:stop] * self.l1_output_scale
+            data[k] = (out[1][:, start:stop] * self.l1_output_scale).squeeze()
             start += self.n_channel
             stop += self.n_channel
         if self.max_l >= 2:
             start, stop = 0, self.n_channel
             for k in self.l2_key:
-                data[k] = out[2][:, start:stop] * self.l2_output_scale
+                data[k] = (out[2][:, start:stop] * self.l2_output_scale).squeeze()
                 start += self.n_channel
                 stop += self.n_channel
+           
        
         return data 
 


### PR DESCRIPTION
Adds quadrupole prediction to tensorreadout and les_wrapper:

multipoles = TensorReadout(
    max_l=2,
    l0_key='kappas',
    l1_key='dipoles',
    l2_key=['alphas','quads'],
    l0_output_scale=0.1,
    l1_output_scale=1.0,
    l2_output_scale=1.0,
)

les_e = LesWrapper(
    dipole_key='dipoles',
    quads_key='quads',
    alpha_key='alphas',
    energy_key='ewald_potential',
    compute_bec=False,
    make_alpha_positive=True,
    add_scalar_alpha=True,
)

Tensorreadout now accepts lists of outputs